### PR TITLE
Effectively make this project `no_std`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ macro_rules! array_ref {
 macro_rules! array_refs {
     ( $arr:expr, $( $pre:expr ),* ; .. ;  $( $post:expr ),* ) => {{
         {
-            use std::slice;
+            use core::slice;
             #[inline]
             #[allow(unused_assignments)]
             #[allow(clippy::eval_order_dependence)]
@@ -202,7 +202,7 @@ macro_rules! array_refs {
 macro_rules! mut_array_refs {
     ( $arr:expr, $( $pre:expr ),* ; .. ;  $( $post:expr ),* ) => {{
         {
-            use std::slice;
+            use core::slice;
             #[inline]
             #[allow(unused_assignments)]
             #[allow(clippy::eval_order_dependence)]


### PR DESCRIPTION
Replaces `std::slice` with `core::slice`.

The current test suite didn't trigger an error because `std` is imported if `#[cfg(test)]`.