### PR TITLE
Remove unsafe from array_ref! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Macros to take array references of slices"
 license = "BSD-2-Clause"
 repository = "https://github.com/droundy/arrayref"
 documentation = "https://docs.rs/arrayref"
+edition = "2021"
 
 [dev-dependencies]
 quickcheck = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,17 +58,16 @@ macro_rules! array_ref {
     ($arr:expr, $offset:expr, $len:expr) => {{
         {
             #[inline]
-            unsafe fn as_array<T>(slice: &[T]) -> &[T; $len] {
-                &*(slice.as_ptr() as *const [_; $len])
+            fn as_array<T>(slice: &[T]) -> &[T; $len] {
+                slice
+                    .try_into()
+                    .expect("array ref len and offset should be valid for provided array")
             }
             let offset = $offset;
-            let slice = & $arr[offset..offset + $len];
-            #[allow(unused_unsafe)]
-            unsafe {
-                as_array(slice)
-            }
+            let slice = &$arr[offset..offset + $len];
+            as_array(slice)
         }
-    }}
+    }};
 }
 
 /// You can use `array_refs` to generate a series of array references


### PR DESCRIPTION
unsafe is no longer needed here since this is now supported in stable rust, the panic behavior is the same as before since it would panic anyways if the slice index was out of bounds