### PR TITLE
Fix some bounds-arithmetic flaws in the tests, and update to quickcheck v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/droundy/arrayref"
 documentation = "https://docs.rs/arrayref"
 
 [dev-dependencies]
-quickcheck = "0.6"
+quickcheck = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,7 @@ mod test {
     #[test]
     fn check_array_ref_5() {
         fn f(data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
-            if data.len() < offset + 5 {
+            if data.len() < 5 || data.len() - 5 < offset {
                 return quickcheck::TestResult::discard();
             }
             let out = array_ref!(data, offset, 5);
@@ -351,7 +351,7 @@ mod test {
     #[test]
     fn check_array_ref_out_of_bounds_5() {
         fn f(data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
-            if data.len() >= offset + 5 {
+            if data.len() >= 5 && data.len() - 5 >= offset {
                 return quickcheck::TestResult::discard();
             }
             quickcheck::TestResult::must_fail(move || {
@@ -364,7 +364,7 @@ mod test {
     #[test]
     fn check_array_mut_ref_7() {
         fn f(mut data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
-            if data.len() < offset + 7 {
+            if data.len() < 7 || data.len() - 7 < offset {
                 return quickcheck::TestResult::discard();
             }
             let out = array_mut_ref!(data, offset, 7);
@@ -377,7 +377,7 @@ mod test {
     #[test]
     fn check_array_mut_ref_out_of_bounds_32() {
         fn f(mut data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
-            if data.len() >= offset + 32 {
+            if data.len() >= 32 && data.len() - 32 >= offset {
                 return quickcheck::TestResult::discard();
             }
             quickcheck::TestResult::must_fail(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,6 +339,8 @@ mod test {
     #[test]
     fn check_array_ref_5() {
         fn f(data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() < offset + 5
             if data.len() < 5 || data.len() - 5 < offset {
                 return quickcheck::TestResult::discard();
             }
@@ -351,6 +353,8 @@ mod test {
     #[test]
     fn check_array_ref_out_of_bounds_5() {
         fn f(data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() >= offset + 5
             if data.len() >= 5 && data.len() - 5 >= offset {
                 return quickcheck::TestResult::discard();
             }
@@ -364,6 +368,8 @@ mod test {
     #[test]
     fn check_array_mut_ref_7() {
         fn f(mut data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() < offset + 7
             if data.len() < 7 || data.len() - 7 < offset {
                 return quickcheck::TestResult::discard();
             }
@@ -377,6 +383,8 @@ mod test {
     #[test]
     fn check_array_mut_ref_out_of_bounds_32() {
         fn f(mut data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() >= offset + 32
             if data.len() >= 32 && data.len() - 32 >= offset {
                 return quickcheck::TestResult::discard();
             }


### PR DESCRIPTION
Some tests relied on unsigned arithmetic that could wrap around, and quickcheck 1.0 was able to reveal the problem. All of the issues were in the tests rather than in the implementation.

Fixes https://github.com/droundy/arrayref/issues/22. Fixes compatibility with quickcheck v1.

The second commit actually updates the `quickcheck` dev-dependency to 1.0.